### PR TITLE
Removed unnecessary steps from ci  

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements
         run: pip install -r requirements/ci.txt
-      - name: Make migartions
-        run: python manage.py makemigrations
-      - name: Migrate
-        run: python manage.py migrate
       - name: Run Tests
         run: python manage.py test


### PR DESCRIPTION
the test command makes its own db anyway so no need to run migrations.
the mistake was not including migrations in the repo and not setting auth method for postgres